### PR TITLE
Prioritize 'exiton' over 'expect_raw' in non-interactive mode

### DIFF
--- a/novaboot
+++ b/novaboot
@@ -1299,7 +1299,7 @@ if ($interaction && defined $exp) {
     print STDERR "novaboot: Serial line interaction (press $interrupt to interrupt)...\n";
     $exp->log_stdout(1);
     if (@exiton) {
-	$exp->expect($exiton_timeout, @expect_raw, @exiton) || die("exiton: " . ($! || "timeout"));
+	$exp->expect($exiton_timeout, @exiton, @expect_raw) || die("exiton: " . ($! || "timeout"));
     } else {
 	my @inputs = ($exp);
 	my $infile = new IO::File;


### PR DESCRIPTION
Hi Michal,

during recent experiments with serial line communication, I came across the following use case:
- expect a drop into serial console to which a command should be sent and its outcome checked
- if the command is a success, send `reboot` request
- if the command fails, simply `exiton`

Specifically the following was added on `novaboot` command line:
```--expect='/ # ' --sendcont="if false; then echo -e '\\\x66\\\x6c\\\x61\\\x73\\\x68\\\x5f\\\x73\\\x75\\\x63\\\x63\\\x65\\\x73\\\x73'; else echo -e '\\\x66\\\x6c\\\x61\\\x73\\\x68\\\x5f\\\x66\\\x61\\\x69\\\x6c'; fi\n" --expect="flash_success" --send="reboot -f\n" --exiton="flash_fail" --exiton-timeout=1200```

With the current priority of `expect_raw` over `exiton`, if the `if` evaluates to false, the `exiton` actually never happens as the `flash_fail` is in the buffer, but only `/ # ` gets evaluated and this loop repeats.

Example from one such run:
```
if false; then echo -e '\x66\x6c\x61\x73\x68\x5f\x73\x75\x63\x63\x65\x73\x73
'; else echo -e '\x66\x6c\x61\x73\x68\x5f\x66\x61\x69\x6c'; fi
flash_fail
/ # 
handle id(3): Does `if false; then echo -e \'\\x66\\x6c\\x61\\x73\\x68\\x5f\\x73\\x75\\x63\\x63\\x65\\x73\\x73\r\r\n\'; else echo -e \'\\x66\\x6c\\x61\\x73\\x68\\x5f\\x66\\x61\\x69\\x6c\'; fi\r\nflash_fail\r\n/ # '
match:
  pattern #1: -ex `flash_success'? No.
  pattern #2: -ex `/ # '? YES!!
    Before match string: `if false; then echo -e \'\\x66\\x6c\\x61\\x73\\x68\\x5f\\x73\\x75\\x63\\x63\\x65\\x73\\x73\r\r\n\'; else echo -e \'\\x66\\x6c\\x61\\x73\\x68\\x5f\\x66\\x61\\x69\\x6c\'; fi\r\nflash_fail\r\n'
    Match string: `/ # '
    After match string: `'
    Matchlist: ()
Calling hook CODE(0x557c6a381448)...
Sending 'if false; then echo -e \'\\x66\\x6c\\x61\\x73\\x68\\x5f\\x73\\x75\\x63\\x63\\x65\\x73\\x73\'; else echo -e \'\\x66\\x6c\\x61\\x73\\x68\\x5f\\x66\\x61\\x69\\x6c\'; fi\n' to handle id(3)
 at /usr/share/perl5/Expect.pm line 1265, <ARGV> line 10.
        Expect::print(Expect=GLOB(0x557c6a346eb0), "if false; then echo -e '\\x66\\x6c\\x61\\x73\\x68\\x5f\\x73\\x75\\x63\\"...) called at /usr/bin/novaboot line 165
        main::__ANON__(Expect=GLOB(0x557c6a346eb0)) called at /usr/share/perl5/Expect.pm line 761
        Expect::_multi_expect(1200, undef, ARRAY(0x557c6a378650)) called at /usr/share/perl5/Expect.pm line 566
        Expect::expect(Expect=GLOB(0x557c6a346eb0), 1200, "flash_success", CODE(0x557c6a242300), "/ # ", CODE(0x557c6a381448), "flash_fail") called at /usr/bin/novaboot line 1302
Continuing expect, restarting timeout...
```

I propose a patch to always prioritize the `exiton` to terminate `novaboot` in such case.

Regards,
Martin