### PR TITLE
Use grub instead of pxegrub.pxe

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -371,9 +371,13 @@ Alias for B<--prefix>.
 =item --grub2[=I<filename>]
 
 Generate GRUB2 menu entry in I<filename>. If I<filename> is not
-specified F<grub.cfg> is used. The content of the menu entry can be
+specified F<./boot/grub/grub.cfg> is used. The content of the menu entry can be
 customized with B<--grub-preamble>, B<--grub2-prolog> or
 B<--grub_prefix> options.
+
+GRUB2 can boot multiboot-compliant kernels and a few kernels with specific
+support. L</BOOT_METHOD> could be used to specify the command used by GRUB2 to
+load the kernel. See L<GNU GRUB Manual|https://www.gnu.org/software/grub/manual/grub/grub.html#Booting>.
 
 To use the generated menu entry on your development
 machine that uses GRUB2, append the following snippet to
@@ -930,6 +934,11 @@ Example (Zynq system update via U-Boot):
 The following variables are interpreted in the novaboot script:
 
 =over 8
+
+=item BOOT_METHOD
+
+Specifies the way GRUB2 boots the kernel. For kernels with multiboot
+support use C<multiboot> method (the default). For Linux kernel use C<linux> method.
 
 =item BUILDDIR
 

--- a/novaboot
+++ b/novaboot
@@ -580,19 +580,19 @@ sub generate_grub2_config($$$$;$$)
     print $fg "menuentry $title {\n";
     print $fg "$prolog\n" if $prolog;
     my $first = 1;
+    my $boot_method = $variables->{BOOT_METHOD} // "multiboot";
+    my $module_load_method = "module";
+    if ($boot_method == "linux") {
+    $module_load_method = "initrd";
+    }
     foreach (@$modules_ref) {
 	if ($first) {
 	    $first = 0;
 	    my ($kbin, $kcmd) = split(' ', $_, 2);
 	    $kcmd = '' if !defined $kcmd;
-	    my $boot_method = $variables->{BOOT_METHOD} // "multiboot";
 	    print $fg "  $boot_method ${base}$kbin $kcmd\n";
 	} else {
 	    my @args = split;
-	    my $module_load_method = "module";
-	    if (exists $variables->{MODULE_LOAD_METHOD}) {
-	    $module_load_method = $variables->{MODULE_LOAD_METHOD};
-	    }
 	    # GRUB2 doesn't pass filename in multiboot info so we have to duplicate it here
 	    $_ = join(' ', ($args[0], @args));
 	    s|\brom://|$rom_prefix|g; # We do not need to translate path for GRUB2
@@ -2346,13 +2346,6 @@ configuration file with the C<$hypervisor> variable. The value should
 contain the name of the kernel image as well as its command line
 parameters. If this variable is defined and non-empty, the variable
 HYPERVISOR_PARAMS is not used.
-
-=item MODULE_LOAD_METHOD
-
-Specifies the way C<$grub2> load modules for a kernel. This variable accompanies
-L</BOOT_METHOD>. For kernels with multiboot support use C<$module> method. For
-Linux kernel use C<$initrd> method to load initial ram disk image. By default,
-C<$module> is used.
 
 =item NO_BOOT
 

--- a/novaboot
+++ b/novaboot
@@ -22,6 +22,7 @@ use Getopt::Long qw(GetOptionsFromString GetOptionsFromArray);
 use Pod::Usage;
 use File::Basename;
 use File::Spec;
+use File::Path qw(make_path);
 use IO::Handle;
 use Time::HiRes("usleep");
 use Socket;
@@ -346,7 +347,7 @@ if (defined $serial) {
     $ENV{NB_SERIAL} = $serial;
 }
 if (defined $grub_config) { $grub_config ||= "menu.lst"; }
-if (defined $grub2_config) { $grub2_config ||= "grub.cfg"; }
+if (defined $grub2_config) { $grub2_config ||= "./boot/grub/grub.cfg"; }
 
 ## Parse the novaboot script(s)
 my @scripts;
@@ -568,6 +569,10 @@ sub generate_grub2_config($$$$;$$)
 {
     my ($filename, $title, $base, $modules_ref, $preamble, $prolog) = @_;
     if ($base && substr($base,-1,1) ne '/') { $base = "$base/"; };
+    my $dir = dirname($filename);
+    make_path($dir, {
+                chmod => 0755,
+    });
     open(my $fg, '>', $filename) or die "$filename: $!";
     print $fg "$preamble\n" if $preamble;
     $title ||= 'novaboot';
@@ -1740,7 +1745,7 @@ Alias for B<--prefix>.
 =item --grub2[=I<filename>]
 
 Generate GRUB2 menu entry in I<filename>. If I<filename> is not
-specified F<grub.cfg> is used. The content of the menu entry can be
+specified F<./boot/grub/grub.cfg> is used. The content of the menu entry can be
 customized with B<--grub-preamble>, B<--grub2-prolog> or
 B<--grub_prefix> options.
 

--- a/novaboot
+++ b/novaboot
@@ -1170,8 +1170,7 @@ r     \\.efi.*   \\.efi";
     system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $builddir");
 
     # Prepare a GRUB netboot directory
-    system_verbose("grub-mknetdir --net-directory=$builddir --directory=/usr/lib/grub/x86_64-efi");
-    system_verbose("grub-mknetdir --net-directory=$builddir --directory=/usr/lib/grub/i386-pc");
+    system_verbose("grub-mknetdir --net-directory=$builddir");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);

--- a/novaboot
+++ b/novaboot
@@ -2304,7 +2304,8 @@ The following variables are interpreted in the novaboot script:
 =item BOOT_METHOD
 
 Specifies the way C<$grub2> boots the kernel. For kernels with multiboot
-support set it to C<$multiboot> method. For Linux kernel set it C<$linux> method.
+support use C<$multiboot> method. For Linux kernel use C<$linux> method. By
+default, C<$multiboot> is used.
 
 =item BUILDDIR
 

--- a/novaboot
+++ b/novaboot
@@ -1159,9 +1159,15 @@ host server {
 
 if (defined $dhcp_tftp || defined $tftp) {
     $tftp_port ||= 69;
+    # Generate TFTP mapfile
+    open(my $fh, '>', "$builddir/tftpboot/mapfile");
+    print $fh "# Some PXE clients (mainly UEFI) have bug. They add zero byte to the end of the
+# path name. This rule removes it
+r     \\.efi.*   \\.efi";
+    close($fh);
     # Unfortunately, tftpd requires root privileges even with
     # non-privileged (>1023) port due to initgroups().
-    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid  --address :$tftp_port $builddir/tftpboot");
+    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $builddir/tftpboot");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);

--- a/novaboot
+++ b/novaboot
@@ -2314,9 +2314,8 @@ The following variables are interpreted in the novaboot script:
 
 =item BOOT_METHOD
 
-Specifies the way C<$grub2> boots the kernel. For kernels with multiboot
-support use C<$multiboot> method. For Linux kernel use C<$linux> method. By
-default, C<$multiboot> is used.
+Specifies the way GRUB2 boots the kernel. For kernels with multiboot
+support use C<multiboot> method (the default). For Linux kernel use C<linux> method.
 
 =item BUILDDIR
 

--- a/novaboot
+++ b/novaboot
@@ -591,10 +591,14 @@ sub generate_grub2_config($$$$;$$)
 	    print $fg "  $boot_method ${base}$kbin $kcmd\n";
 	} else {
 	    my @args = split;
+	    my $module_load_method = "module";
+	    if (exists $variables->{MODULE_LOAD_METHOD}) {
+	    $module_load_method = $variables->{MODULE_LOAD_METHOD};
+	    }
 	    # GRUB2 doesn't pass filename in multiboot info so we have to duplicate it here
 	    $_ = join(' ', ($args[0], @args));
 	    s|\brom://|$rom_prefix|g; # We do not need to translate path for GRUB2
-	    print $fg "  module $base$_\n";
+	    print $fg "  $module_load_method $base$_\n";
 	}
     }
     print $fg "}\n";
@@ -2336,6 +2340,13 @@ configuration file with the C<$hypervisor> variable. The value should
 contain the name of the kernel image as well as its command line
 parameters. If this variable is defined and non-empty, the variable
 HYPERVISOR_PARAMS is not used.
+
+=item MODULE_LOAD_METHOD
+
+Specifies the way C<$grub2> load modules for a kernel. This variable accompanies
+L</BOOT_METHOD>. For kernels with multiboot support use C<$module> method. For
+Linux kernel use C<$initrd> method to load initial ram disk image. By default,
+C<$module> is used.
 
 =item NO_BOOT
 

--- a/novaboot
+++ b/novaboot
@@ -1172,18 +1172,22 @@ host server {
 
 if (defined $dhcp_tftp || defined $tftp) {
     $tftp_port ||= 69;
+    my $tftp_root = "$builddir";
+    if (defined $server) {
+        $tftp_root = $tftp_root . "/$server";
+    }
     # Generate TFTP mapfile
-    open(my $fh, '>', "$builddir/mapfile");
+    open(my $fh, '>', "$tftp_root/mapfile");
     print $fh "# Some PXE clients (mainly UEFI) have bug. They add zero byte to the end of the
 # path name. This rule removes it
 r     \\.efi.*   \\.efi";
     close($fh);
     # Unfortunately, tftpd requires root privileges even with
     # non-privileged (>1023) port due to initgroups().
-    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $builddir");
+    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile $builddir/tftpd.pid -m mapfile --address :$tftp_port $tftp_root");
 
     # Prepare a GRUB netboot directory
-    system_verbose("grub-mknetdir --net-directory=$builddir");
+    system_verbose("grub-mknetdir --net-directory=$tftp_root");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);

--- a/novaboot
+++ b/novaboot
@@ -1172,9 +1172,7 @@ host server {
 if (defined $dhcp_tftp || defined $tftp) {
     $tftp_port ||= 69;
     my $tftp_root = "$builddir";
-    if (defined $server) {
-        $tftp_root = $tftp_root . "/$server";
-    }
+    $tftp_root = "$server" if(defined $server);
 
     # Prepare a GRUB netboot directory
     system_verbose("grub-mknetdir --net-directory=$tftp_root");

--- a/novaboot
+++ b/novaboot
@@ -1136,10 +1136,10 @@ class \"pxe-clients\" {
      match option vendor-class-identifier;
 }
 subclass \"pxe-clients\"  \"PXEClient:Arch:00000:UNDI:002001\" {
-     option bootfile-name \"bios/pxelinux.0\";
+     option bootfile-name \"boot/grub/i386-pc/core.0\";
 }
 subclass \"pxe-clients\"  \"PXEClient:Arch:00007:UNDI:003016\" {
-     option bootfile-name \"efi.x86/syslinux.efi\";
+     option bootfile-name \"boot/grub/x86_64-efi/core.efi\";
 }
 host server {
 	hardware ethernet $mac;

--- a/novaboot
+++ b/novaboot
@@ -1127,10 +1127,19 @@ if (defined $dhcp_tftp)
     open(my $fh, '>', 'dhcpd.conf');
     my $mac = `cat /sys/class/net/$netif/address`;
     chomp $mac;
-    print $fh "subnet 10.23.23.0 netmask 255.255.255.0 {
-		      range 10.23.23.10 10.23.23.100;
-		      filename \"bin/boot/grub/pxegrub.pxe\";
-		      next-server 10.23.23.1;
+    print $fh "
+subnet 10.23.23.0 netmask 255.255.255.0 {
+	range 10.23.23.10 10.23.23.100;
+	next-server 10.23.23.1;
+}
+class \"pxe-clients\" {
+     match option vendor-class-identifier;
+}
+subclass \"pxe-clients\"  \"PXEClient:Arch:00000:UNDI:002001\" {
+     option bootfile-name \"bios/pxelinux.0\";
+}
+subclass \"pxe-clients\"  \"PXEClient:Arch:00007:UNDI:003016\" {
+     option bootfile-name \"efi.x86/syslinux.efi\";
 }
 host server {
 	hardware ethernet $mac;

--- a/novaboot
+++ b/novaboot
@@ -582,8 +582,9 @@ sub generate_grub2_config($$$$;$$)
     my $first = 1;
     my $boot_method = $variables->{BOOT_METHOD} // "multiboot";
     my $module_load_method = "module";
-    if ($boot_method == "linux") {
+    if ($boot_method eq "linux") {
     $module_load_method = "initrd";
+    die('Too many "load" lines for Linux kernel') if (scalar(@$modules_ref) > 2);
     }
     foreach (@$modules_ref) {
 	if ($first) {

--- a/novaboot
+++ b/novaboot
@@ -545,7 +545,7 @@ sub generate_syslinux_config($$$$)
 
     if (system("file $kbin|grep 'Linux kernel'") == 0) {
 	my $initrd = @$modules_ref[1];
-	die('To many "load" lines for Linux kernel') if (scalar @$modules_ref > 2);
+	die('Too many "load" lines for Linux kernel') if (scalar @$modules_ref > 2);
 	print $fg "LINUX $base$kbin\n";
 	print $fg "APPEND $kcmd\n";
 	print $fg "INITRD $base$initrd\n";

--- a/novaboot
+++ b/novaboot
@@ -1169,6 +1169,10 @@ r     \\.efi.*   \\.efi";
     # non-privileged (>1023) port due to initgroups().
     system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $builddir/tftpboot");
 
+    # Prepare a GRUB netboot directory
+    system_verbose("grub-mknetdir --net-directory=$builddir/tftpboot --directory=/usr/lib/grub/x86_64-efi");
+    system_verbose("grub-mknetdir --net-directory=$builddir/tftpboot --directory=/usr/lib/grub/i386-pc");
+
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);
 			  system_verbose('sudo pkill --pidfile=tftpd.pid'); };

--- a/novaboot
+++ b/novaboot
@@ -585,10 +585,7 @@ sub generate_grub2_config($$$$;$$)
 	    $first = 0;
 	    my ($kbin, $kcmd) = split(' ', $_, 2);
 	    $kcmd = '' if !defined $kcmd;
-	    my $boot_method = "multiboot";
-	    if (exists $variables->{BOOT_METHOD}) {
-	    $boot_method = $variables->{BOOT_METHOD};
-	    }
+	    my $boot_method = $variables->{BOOT_METHOD} // "multiboot";
 	    print $fg "  $boot_method ${base}$kbin $kcmd\n";
 	} else {
 	    my @args = split;

--- a/novaboot
+++ b/novaboot
@@ -1757,6 +1757,10 @@ specified F<./boot/grub/grub.cfg> is used. The content of the menu entry can be
 customized with B<--grub-preamble>, B<--grub2-prolog> or
 B<--grub_prefix> options.
 
+GRUB2 can boot multiboot-compliant kernels and a few kernels with specific
+support. L</BOOT_METHOD> could be used to specify the command used by GRUB2 to
+load the kernel. See L<GNU GRUB Manual|https://www.gnu.org/software/grub/manual/grub/grub.html#Booting>.
+
 To use the generated menu entry on your development
 machine that uses GRUB2, append the following snippet to
 F</etc/grub.d/40_custom> file and regenerate your grub configuration,

--- a/novaboot
+++ b/novaboot
@@ -1160,18 +1160,18 @@ host server {
 if (defined $dhcp_tftp || defined $tftp) {
     $tftp_port ||= 69;
     # Generate TFTP mapfile
-    open(my $fh, '>', "$builddir/tftpboot/mapfile");
+    open(my $fh, '>', "$builddir/mapfile");
     print $fh "# Some PXE clients (mainly UEFI) have bug. They add zero byte to the end of the
 # path name. This rule removes it
 r     \\.efi.*   \\.efi";
     close($fh);
     # Unfortunately, tftpd requires root privileges even with
     # non-privileged (>1023) port due to initgroups().
-    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $builddir/tftpboot");
+    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $builddir");
 
     # Prepare a GRUB netboot directory
-    system_verbose("grub-mknetdir --net-directory=$builddir/tftpboot --directory=/usr/lib/grub/x86_64-efi");
-    system_verbose("grub-mknetdir --net-directory=$builddir/tftpboot --directory=/usr/lib/grub/i386-pc");
+    system_verbose("grub-mknetdir --net-directory=$builddir --directory=/usr/lib/grub/x86_64-efi");
+    system_verbose("grub-mknetdir --net-directory=$builddir --directory=/usr/lib/grub/i386-pc");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);

--- a/novaboot
+++ b/novaboot
@@ -1185,14 +1185,14 @@ r     \\.efi.*   \\.efi";
     close($fh);
     # Unfortunately, tftpd requires root privileges even with
     # non-privileged (>1023) port due to initgroups().
-    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile $builddir/tftpd.pid -m mapfile --address :$tftp_port $tftp_root");
+    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid -m mapfile --address :$tftp_port $tftp_root");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);
-			  system_verbose('sudo pkill --pidfile=tftpd.pid'); };
+			  system_verbose("sudo pkill --pidfile=$tftp_root/tftpd.pid"); };
 
     # We have to kill tftpd explicitely, because it is not in our process group
-    $SIG{INT} = sub { system_verbose('sudo pkill --pidfile=tftpd.pid'); exit(0); };
+    $SIG{INT} = sub { system_verbose("sudo pkill --pidfile=$tftp_root/tftpd.pid"); exit(0); };
 }
 
 ### AMT IDE-R

--- a/novaboot
+++ b/novaboot
@@ -1177,6 +1177,10 @@ if (defined $dhcp_tftp || defined $tftp) {
     if (defined $server) {
         $tftp_root = $tftp_root . "/$server";
     }
+
+    # Prepare a GRUB netboot directory
+    system_verbose("grub-mknetdir --net-directory=$tftp_root");
+
     # Generate TFTP mapfile
     open(my $fh, '>', "$tftp_root/mapfile");
     print $fh "# Some PXE clients (mainly UEFI) have bug. They add zero byte to the end of the
@@ -1186,9 +1190,6 @@ r     \\.efi.*   \\.efi";
     # Unfortunately, tftpd requires root privileges even with
     # non-privileged (>1023) port due to initgroups().
     system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile $builddir/tftpd.pid -m mapfile --address :$tftp_port $tftp_root");
-
-    # Prepare a GRUB netboot directory
-    system_verbose("grub-mknetdir --net-directory=$tftp_root");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);

--- a/novaboot
+++ b/novaboot
@@ -579,7 +579,11 @@ sub generate_grub2_config($$$$;$$)
 	    $first = 0;
 	    my ($kbin, $kcmd) = split(' ', $_, 2);
 	    $kcmd = '' if !defined $kcmd;
-	    print $fg "  multiboot ${base}$kbin $kcmd\n";
+	    my $boot_method = "multiboot";
+	    if (exists $variables->{BOOT_METHOD}) {
+	    $boot_method = $variables->{BOOT_METHOD};
+	    }
+	    print $fg "  $boot_method ${base}$kbin $kcmd\n";
 	} else {
 	    my @args = split;
 	    # GRUB2 doesn't pass filename in multiboot info so we have to duplicate it here
@@ -2291,6 +2295,11 @@ Example (Zynq system update via U-Boot):
 The following variables are interpreted in the novaboot script:
 
 =over 8
+
+=item BOOT_METHOD
+
+Specifies the way C<$grub2> boots the kernel. For kernels with multiboot
+support set it to C<$multiboot> method. For Linux kernel set it C<$linux> method.
 
 =item BUILDDIR
 

--- a/novaboot
+++ b/novaboot
@@ -56,9 +56,9 @@ $CFG::default_target = '';
 $CFG::netif = 'eth0';
 %CFG::targets = (
     'qemu' => '--qemu',
-    "tud" => '--server=erwin.inf.tu-dresden.de:~sojka/boot/novaboot --rsync-flags="--chmod=Dg+s,ug+w,o-w,+rX --rsync-path=\"umask 002 && rsync\"" --grub --grub-prefix=(nd)/tftpboot/sojka/novaboot --grub-preamble="timeout 0" --concat --iprelay=141.76.48.80:2324 --scriptmod=s/\\\\bhostserial\\\\b/hostserialpci/g',
+    "tud" => '--copy=erwin.inf.tu-dresden.de:~sojka/boot/novaboot --rsync-flags="--chmod=Dg+s,ug+w,o-w,+rX --rsync-path=\"umask 002 && rsync\"" --grub --grub-prefix=(nd)/tftpboot/sojka/novaboot --grub-preamble="timeout 0" --concat --iprelay=141.76.48.80:2324 --scriptmod=s/\\\\bhostserial\\\\b/hostserialpci/g',
     "novabox" => '--ssh=novabox@rtime.felk.cvut.cz',
-    "localhost" => '--scriptmod=s/console=tty[A-Z0-9,]+// --server=/boot/novaboot/$NAME --grub2 --grub-prefix=/boot/novaboot/$NAME --grub2-prolog="  set root=\'(hd0,msdos1)\'"',
+    "localhost" => '--scriptmod=s/console=tty[A-Z0-9,]+// --copy=/boot/novaboot/$NAME --grub2 --grub-prefix=/boot/novaboot/$NAME --grub2-prolog="  set root=\'(hd0,msdos1)\'"',
     "ryu" =>  '--uboot --uboot-init="mw f0000b00 \${psc_cfg}; sleep 1" --uboot-addr kernel=800000 --uboot-addr ramdisk=b00000 --uboot-addr fdt=7f0000',
     "ryuglab" => '--target ryu --ssh=ryu@pc-sojkam.felk.cvut.cz',
     "ryulocal" => '--target ryu --dhcp-tftp --serial --reset-cmd="if which dtrrts; then dtrrts $NB_SERIAL 0 1; sleep 0.1; dtrrts $NB_SERIAL 1 1; fi"',
@@ -234,6 +234,7 @@ my %opt_spec = (
     "sendcont=s"     => \&handle_send,
     "serial|s:s"     => \$serial,
     "server:s" 	     => \$server,
+    "copy:s" 	     => \$server,
     "ssh:s"	     => \&handle_novaboot_server,
     "strip-rom"	     => sub { $rom_prefix = ''; },
     "stty=s"	     => \$stty,
@@ -1436,13 +1437,13 @@ to configure novaboot for them. The setups are:
 This requires to configure everything on the laptop side, including a
 serial line connection (L</--serial>, L</--remote-cmd>, ...), power
 on/off/reset commands (L</--reset-cmd>, ...), TFTP server
-(L</--server>, L</--prefix>...), device IP addresses, etc.
+(L</--copy>, L</--prefix>...), device IP addresses, etc.
 
 =item B: Laptop, target device and external TFTP server
 
 Like the previous setup, but the TFTP (and maybe DHCP) configuration
 is handled by a server. Novaboot users need to understand where to
-copy their files to the TFTP server (L</--server>) and which IP
+copy their files to the TFTP server (L</--copy>) and which IP
 addresses their target will get, but do not need to configure the
 servers themselves.
 
@@ -1486,7 +1487,7 @@ with all other files needed for booting to a remote TFTP server. Then
 use a TCP/IP-controlled relay/serial-to-TCP converter to reset the
 target and receive its serial output.
 
- ./mylinux --grub2 --server=192.168.1.1:/tftp --iprelay=192.168.1.2
+ ./mylinux --grub2 --copy=192.168.1.1:/tftp --iprelay=192.168.1.2
 
 Alternatively, you can put these switches to the configuration file
 and run:
@@ -1638,7 +1639,7 @@ Configures novaboot to control the target via C<novaboot-shell>
 running remotely via SSH.
 
 Using this option is the same as specifying B<--remote-cmd>,
-B<--remote-expect>, B<--server> B<--rsync-flags>, B<--prefix> and
+B<--remote-expect>, B<--copy> B<--rsync-flags>, B<--prefix> and
 B<--reset-cmd> manually in a way compatible with C<novaboot-shell>.
 The server can be configured to provide other, safe bootloader-related
 options, to the client. When this happens, novaboot prints them to
@@ -1946,6 +1947,10 @@ of the novaboot script (see also B<--name>).
 
 =item --server[=[[user@]server:]path]
 
+Deprecated. Use B<--copy> instead.
+
+=item --copy[=[[user@]server:]path]
+
 Copy all files needed for booting to another location. The files will
 be copied (by B<rsync> tool) to the directory I<path>. If the I<path>
 contains string $NAME, it will be replaced with the name of the
@@ -1954,13 +1959,13 @@ novaboot script (see also B<--name>).
 =item --rsync-flags=I<flags>
 
 Specifies I<flags> to append to F<rsync> command line when
-copying files as a result of I<--server> option.
+copying files as a result of I<--copy> option.
 
 =item --concat
 
-If B<--server> is used and its value ends with $NAME, then after
+If B<--copy> is used and its value ends with $NAME, then after
 copying the files, a new bootloader configuration file (e.g. menu.lst)
-is created at I<path-wo-name>, i.e. the path specified by B<--server>
+is created at I<path-wo-name>, i.e. the path specified by B<--copy>
 with $NAME part removed. The content of the file is created by
 concatenating all files of the same name from all subdirectories of
 I<path-wo-name> found on the "server".
@@ -2427,11 +2432,11 @@ Hash of target definitions to be used with the B<--target> option. The
 key is the identifier of the target, the value is the string with
 command line options. For instance, if the configuration file contains:
 
- $targets{'mybox'} = '--server=boot:/tftproot --serial=/dev/ttyUSB0 --grub',
+ $targets{'mybox'} = '--copy=boot:/tftproot --serial=/dev/ttyUSB0 --grub',
 
 then the following two commands are equivalent:
 
- ./myos --server=boot:/tftproot --serial=/dev/ttyUSB0 --grub
+ ./myos --copy=boot:/tftproot --serial=/dev/ttyUSB0 --grub
  ./myos -t mybox
 
 =back

--- a/novaboot
+++ b/novaboot
@@ -1152,7 +1152,7 @@ if (defined $dhcp_tftp || defined $tftp) {
     $tftp_port ||= 69;
     # Unfortunately, tftpd requires root privileges even with
     # non-privileged (>1023) port due to initgroups().
-    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid  --address :$tftp_port $builddir");
+    system_verbose("sudo in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid  --address :$tftp_port $builddir/tftpboot");
 
     # Kill server when we die
     $SIG{__DIE__} = sub { system_verbose('sudo pkill --pidfile=dhcpd.pid') if (defined $dhcp_tftp);

--- a/sudoers.novaboot
+++ b/sudoers.novaboot
@@ -5,5 +5,5 @@
 # your_login ALL=NOPASSWD: NOVABOOT_DHCP
 
 # Uncomment the following lines to enable --dhcp-tftp and --tftp options
-# Cmnd_Alias NOVABOOT_TFTP = /usr/sbin/in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid *, /usr/bin/pkill --pidfile=tftpd.pid
+# Cmnd_Alias NOVABOOT_TFTP = /usr/sbin/in.tftpd --listen --secure -v -v -v --pidfile */tftpd.pid *, /usr/bin/pkill --pidfile=tftpd.pid
 # your_login ALL=NOPASSWD: NOVABOOT_TFTP

--- a/sudoers.novaboot
+++ b/sudoers.novaboot
@@ -5,5 +5,5 @@
 # your_login ALL=NOPASSWD: NOVABOOT_DHCP
 
 # Uncomment the following lines to enable --dhcp-tftp and --tftp options
-# Cmnd_Alias NOVABOOT_TFTP = /usr/sbin/in.tftpd --listen --secure -v -v -v --pidfile */tftpd.pid *, /usr/bin/pkill --pidfile=tftpd.pid
+# Cmnd_Alias NOVABOOT_TFTP = /usr/sbin/in.tftpd --listen --secure -v -v -v --pidfile tftpd.pid *, /usr/bin/pkill --pidfile=*/tftpd.pid
 # your_login ALL=NOPASSWD: NOVABOOT_TFTP


### PR DESCRIPTION
In response to https://github.com/wentasah/novaboot/issues/8

I decided to stick with `grub` instead of `pxelinux` as it seems to be more flexible and well-known tool for others (but I also have working version with `pxelinux` 😀).

I tested it on two my machines with legacy boot and EFI boot and works great (with workarounds😁) but I have a few points for clarification/discussion:
1. I see that [`tftpboot` dir](https://github.com/wentasah/novaboot/blob/master/novaboot#L1125) is created but isn't used. TFTP uses `$builddir` as a root. I like the idea of having TFTP root in separate dir as it becomes quite messing when all the configs/temp files are created. Was that the purpose of `tftpboot`?
2. Currently, I use `grub-mknetdir` to create grub netboot for x86_64 and i386-pc (i386-efi is missing). Any better approach here to create it on the fly? (you mentioned that it would be nice to have the possibility to use different bootloaders, any suggestion? I think it will require much more changes and the current solution is just grub centered 😁)
3. When grub is on the target it's looking for `(tftp)/boot/grub/grub.cfg`. By default novaboot puts `grub.cfg` into `(tftp)/grub.cfg`. Is there any reason for this location? It could be solved by providing `--grub2=./boot/grub/grub.cfg` parameter but in the current implementation it won't work as `boot/grub` is created later (creating folder beforehand solves it). Haven't found a simple way to change the path in grub itself (maybe [like this](https://www.gnu.org/software/grub/manual/grub/grub.html#Embedded-configuration))
4. I see that novaboot creates `grub.cfg` with `multiboot` command but as I understood linux kernel doesn't have multiboot header by default. Am I missing something or config-generation was intended to be used only with multiboot compliant systems/images? Even though grub docs seems to mention that linux could be booted as multiboot.
5. The interaction with a target is not completely clear for me. The use case of using ssh after boot up instead of serial isn't considered, right? Because DHCP/TFTP is killed if there's no interaction process and target can't boot. In the [A usecase](https://raw.githubusercontent.com/wentasah/novaboot/master/doc/typical-setups.svg) it could be quite convenient way (ssh).