### PR TITLE
Add support for NFS root using unfs3 on server

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -316,8 +316,8 @@ system. Typical usage in the novaboot script is:
 
 =item --nfsopts=F<options>
 
-Replace string B<$NB_NFSROOT> in the script with F<options>. See
-B<--nfsoroot> for more information.
+Replace string B<$NB_NFSOPTS> in the script with F<options>. See
+B<--nfsroot> for more information.
 
 =item --scriptmod=I<Perl expression>
 


### PR DESCRIPTION
Starts the unfsd for user on get-config request and stops it on last user logout. 

Yet to be done:
- [x] untar received root filesystem into ~/nfsroot/$NB_USER/root
- [ ] start unfsd in new user namespace
- [x] add support for --nfsroot in client (replace a variable on kernel command line with the value of this option)